### PR TITLE
Update spending sorting

### DIFF
--- a/app/services/account.py
+++ b/app/services/account.py
@@ -91,12 +91,12 @@ def _upsert_collection(rows, model_cls, account: Account):
             try:
                 # process through BudgetManager to validate funds and reduce balance
                 bm = BudgetManager(db.session, account.id)
-                today = get_effective_date()
+                selected_date = payload.get("date") or get_effective_date()
                 
                 spend = bm.make_personal_spend(
                     payload["item"],
                     float(payload["amount"]),
-                    today
+                    selected_date
                 )
                 # add to seen list to prevent deletion
                 seen.append(spend.id)

--- a/app/services/dashboard_data.py
+++ b/app/services/dashboard_data.py
@@ -32,7 +32,7 @@ def get_dashboard_data(account):
         bal_status = f"You are ${abs(diff):.2f} below your minimum balance goal."
 
     # sort spendings by date (newest first)
-    sorted_spendings = sorted(account.spendings, key=lambda s: s.date, reverse=True)
+    sorted_spendings = sorted(account.spendings, key=lambda s: (s.date, s.id), reverse=True)
 
     # Filter purchased goals out from the dashboard display
     active_goals = [goal for goal in account.savings_goals if not goal.purchased]


### PR DESCRIPTION
This pull request introduces changes to improve the handling of dates in personal spending operations and enhance sorting logic for account spendings.

### Improvements to date handling:
* [`app/services/account.py`](diffhunk://#diff-aae854b6da60d6ec240b1e637115ea1c090841eaee3355391b0fbf45c532d2b3L94-R99): Modified the `_upsert_collection` method to allow the use of a user-provided date (`payload.get("date")`) for personal spending transactions. If no date is provided, it defaults to the current effective date. (Bug fix: It was using the current date instead of the date the user provides)

### Enhancements to sorting logic:
* [`app/services/dashboard_data.py`](diffhunk://#diff-17adcc84a300d591ba5a661e91218867dba74ea64bdba7c621e7321466ad7a0cL35-R35): Updated the `get_dashboard_data` method to sort spendings by both date and ID (secondary key) in descending order, ensuring consistent ordering for entries with the same date.Now takes into account the most recent additions for each date